### PR TITLE
Update LBFGSB.m

### DIFF
--- a/LBFGSB.m
+++ b/LBFGSB.m
@@ -78,8 +78,9 @@ while ( (get_optimality(x,g,l,u) > tol) && (k < max_iters) )
     Y = [Y y];
     S = [S s];
   else
-    Y(:,1:m-1) = Y(:,2:end);
-    S(:,1:m-1) = S(:,2:end);
+    kf=size(Y);
+    Y(:,1:kf(2)-1) = Y(:,2:end);
+    S(:,1:kf(2)-1) = S(:,2:end);
     Y(:,end) = y;
     S(:,end) = s;
   end

--- a/LBFGSB.m
+++ b/LBFGSB.m
@@ -67,7 +67,7 @@ while ( (get_optimality(x,g,l,u) > tol) && (k < max_iters) )
   [f,g] = feval(func, x);
   y = g - g_old;
   s = x - x_old;
-  curv = abs(transpose(s)*y);
+  curv = (transpose(s)*y); % NOTE: keep sign of curvature
   if (curv < eps)
     fprintf(' warning: negative curvature detected\n');
     fprintf('          skipping L-BFGS update\n');
@@ -380,9 +380,6 @@ Z = [];
 for i=1:length(xc)
   if ( ( xc(i) ~= u(i) ) && ( xc(i) ~= l(i) ) )
     free_vars_idx = [free_vars_idx i];
-    unit = zeros(n,1);
-    unit(i) = 1;
-    Z = [Z unit];
   end
 end
 num_free_vars = length(free_vars_idx);
@@ -394,7 +391,10 @@ if (num_free_vars == 0)
 end
 
 % compute W^T Z, the restriction of W to free variables.
-WTZ = transpose(W)*Z;
+WTZ=zeros(length(c),num_free_vars); % length(c)=2*m
+for i=1:num_free_vars,
+  WTZ(:,i) = W(free_vars_idx(i),:);
+end
 
 % compute the reduced gradient of mk restricted to free variables.
 rr = g + theta*(xc-x) - W*(M*c);

--- a/LBFGSB.m
+++ b/LBFGSB.m
@@ -74,13 +74,13 @@ while ( (get_optimality(x,g,l,u) > tol) && (k < max_iters) )
     k = k+1;
     continue;
   end
-  if (k < m)
+  kf=size(Y); % Check actual size of stored Y
+  if (kf(2) < m)
     Y = [Y y];
     S = [S s];
   else
-    kf=size(Y);
-    Y(:,1:kf(2)-1) = Y(:,2:end);
-    S(:,1:kf(2)-1) = S(:,2:end);
+    Y(:,1:m-1) = Y(:,2:end);
+    S(:,1:m-1) = S(:,2:end);
     Y(:,end) = y;
     S(:,end) = s;
   end


### PR DESCRIPTION
fix curvature calculation, optimize subspace min

- The sign of curvature is lost by taking the abs(), which is not entirely correct (as the next check is done for negative curvature)
- Using a matrix of ones (Z) is not efficient as the WTZ matrix can be directly created by copying rows from W